### PR TITLE
Migrating to null safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.1.0] - 2021-03-23
+
+* Stable null safety release.
+
 ## [1.0.1] - 2020-02-26
 
 * Update dependencies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.1.0] - 2021-03-23
+## [2.0.0] - 2021-03-23
 
 * Stable null safety release.
 

--- a/lib/src/classes/bbox.dart
+++ b/lib/src/classes/bbox.dart
@@ -4,8 +4,12 @@ class BBox {
   double right;
   double left;
 
-  BBox({double top, double bottom, double right, double left})
-      : top = top,
+  BBox({
+    required double top,
+    required double bottom,
+    required double right,
+    required double left,
+  })   : top = top,
         bottom = bottom,
         right = right,
         left = left;

--- a/lib/src/classes/lonlat.dart
+++ b/lib/src/classes/lonlat.dart
@@ -2,7 +2,9 @@ class LonLat {
   double lon;
   double lat;
 
-  LonLat({double lon, double lat})
-      : lon = lon,
+  LonLat({
+    required double lon,
+    required double lat,
+  })   : lon = lon,
         lat = lat;
 }

--- a/lib/src/classes/utm.dart
+++ b/lib/src/classes/utm.dart
@@ -3,14 +3,14 @@ class UTM {
   double northing;
   String zoneLetter;
   int zoneNumber;
-  int accuracy;
+  int? accuracy;
 
   UTM(
-      {double easting,
-      double northing,
-      String zoneLetter,
-      int zoneNumber,
-      int accuracy})
+      {required double easting,
+      required double northing,
+      required String zoneLetter,
+      required int zoneNumber,
+      int? accuracy})
       : easting = easting,
         northing = northing,
         zoneLetter = zoneLetter,

--- a/lib/src/mgrs.dart
+++ b/lib/src/mgrs.dart
@@ -105,7 +105,7 @@ class Mgrs {
   ///      100 m, 2 for 1 km, 1 for 10 km or 0 for 100 km). Optional, default is 5.
   /// @return {string} the MGRS string for the given location and accuracy.
   ///
-  static String forward(List<double> ll, int accuracy) {
+  static String forward(List<double> ll, int? accuracy) {
     accuracy ??= 5;
     if (ll.length != 2) {
       throw Exception(
@@ -136,7 +136,7 @@ class Mgrs {
   /// @param {number} accuracy Accuracy in digits (0-5).
   /// @return {string} MGRS string for the given UTM location.
   ///
-  static String encode(UTM utm, accuracy) {
+  static String encode(UTM utm, int accuracy) {
     // prepend with leading zeroes
     var seasting = '00000${utm.easting.truncate()}';
     var snorthing = '00000${utm.northing.truncate()}';
@@ -398,12 +398,11 @@ class Mgrs {
       const minLatitude = -80;
       var index = ((latitude - minLatitude) / bandHeight).floor();
       return bandLetters[index];
-    } else if (latitude > 84 || latitude < -80) {
+    } else /* if (latitude > 84 || latitude < -80) */ {
       //This is here as an error flag to show that the Latitude is
       //outside MGRS limits
       return 'Z';
     }
-    return null;
   }
 
   ///
@@ -511,8 +510,8 @@ class Mgrs {
     if (utm.accuracy != null) {
       var topRight = UTMtoLL(
         UTM(
-          easting: utm.easting + utm.accuracy,
-          northing: utm.northing + utm.accuracy,
+          easting: utm.easting + utm.accuracy!,
+          northing: utm.northing + utm.accuracy!,
           zoneLetter: utm.zoneLetter,
           zoneNumber: utm.zoneNumber,
           accuracy: null,
@@ -587,14 +586,13 @@ class Mgrs {
     var sep = (remainder / 2).truncate();
     var sepEasting = 0.0;
     var sepNorthing = 0.0;
-    var accuracyBonus;
-    String sepEastingString;
-    String sepNorthingString;
+    int? accuracyBonus;
+
     if (sep > 0) {
       accuracyBonus = (100000 / math.pow(10, sep)).round();
-      sepEastingString = mgrsString.substring(i, i + sep);
+      var sepEastingString = mgrsString.substring(i, i + sep);
       sepEasting = double.parse(sepEastingString) * accuracyBonus;
-      sepNorthingString = mgrsString.substring(i + sep);
+      var sepNorthingString = mgrsString.substring(i + sep);
       sepNorthing = double.parse(sepNorthingString) * accuracyBonus;
     }
     var easting = sepEasting + east100k;

--- a/lib/src/mgrs.dart
+++ b/lib/src/mgrs.dart
@@ -533,7 +533,7 @@ class Mgrs {
   ///     zoneNumber and accuracy (in meters) properties.
   ///
   static UTM decode(String mgrsString) {
-    if (mgrsString == null || mgrsString.isEmpty) {
+    if (mgrsString.isEmpty) {
       throw Exception('MGRSPoint coverting from nothing');
     }
     //remove any spaces in MGRS String
@@ -566,7 +566,7 @@ class Mgrs {
         zoneLetter == 'I' ||
         zoneLetter == 'O') {
       throw Exception(
-          'MGRSPoint zone letter ${zoneLetter} not handled: ${mgrsString}');
+          'MGRSPoint zone letter $zoneLetter not handled: $mgrsString');
     }
     hunK = mgrsString.substring(i, i += 2);
     var set = get100kSetForZone(zoneNumber);
@@ -581,7 +581,7 @@ class Mgrs {
     var remainder = length - i;
     if (remainder % 2 != 0) {
       throw Exception(
-          'MGRSPoint has to have an even number of digits after the zone letter and two 100km letters - front half for easting meters, second half for northing meters ${mgrsString}');
+          'MGRSPoint has to have an even number of digits after the zone letter and two 100km letters - front half for easting meters, second half for northing meters $mgrsString');
     }
     var sep = (remainder / 2).truncate();
     var sepEasting = 0.0;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,11 +4,11 @@ version: 1.0.1
 homepage: https://github.com/fegyi001/mgrs_dart
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  unicode: ^0.2.2
+  unicode: ^0.3.0
 
 dev_dependencies:
-  pedantic: ^1.9.0
-  test: ^1.12.0
+  pedantic: ^1.11.0
+  test: ^1.16.8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mgrs_dart
 description: Utility for converting between WGS84 lat/lng and MGRS coordinates (Dart version of proj4js/mgrs).
-version: 1.0.1
+version: 2.0.0
 homepage: https://github.com/fegyi001/mgrs_dart
 
 environment:

--- a/test/mgrs_dart_test.dart
+++ b/test/mgrs_dart_test.dart
@@ -3,8 +3,8 @@ import 'package:test/test.dart';
 
 void main() {
   group('MGRS test', () {
-    List<double> point;
-    String mgrsString;
+    late List<double> point;
+    late String mgrsString;
 
     setUp(() {
       point = [-115.08209766323476, 36.236123461597515];


### PR DESCRIPTION
This PR adds support for [Sound null safety](https://dart.dev/null-safety).

~~Don't forget to bump version (I think these are breaking changes so update the major version) and update changelog before release / prelease.~~