### PR TITLE
Update dependencies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [3.0.0] - 2025-03-29
+## [3.0.0] - 2025-11-04
 
 * Update minimum Dart version to 3.0.0.
 * Update dependencies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [3.0.0] - 2025-03-29
+
+* Update minimum Dart version to 3.0.0.
+* Update dependencies.
+
 ## [2.0.0] - 2021-03-23
 
 * Stable null safety release.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,7 +1,7 @@
 # Defines a default set of lint rules enforced for
 # projects at Google. For details and rationale,
 # see https://github.com/dart-lang/pedantic#enabled-lints.
-include: package:pedantic/analysis_options.yaml
+include: package:flutter_lints/flutter.yaml
 
 # For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,6 +3,10 @@
 # see https://github.com/dart-lang/pedantic#enabled-lints.
 include: package:flutter_lints/flutter.yaml
 
+formatter:
+  page_width: 80
+  trailing_commas: preserve
+
 # For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.
 # linter:
@@ -12,3 +16,8 @@ include: package:flutter_lints/flutter.yaml
 analyzer:
 #   exclude:
 #     - path/to/excluded/files/**
+
+linter:
+  rules:
+    constant_identifier_names: false
+    non_constant_identifier_names: false

--- a/example/mgrs_dart_example.dart
+++ b/example/mgrs_dart_example.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_print
+
 import 'package:mgrs_dart/mgrs_dart.dart';
 
 void main() {

--- a/lib/mgrs_dart.dart
+++ b/lib/mgrs_dart.dart
@@ -1,4 +1,4 @@
-library mgrs_dart;
+library;
 
 export 'package:mgrs_dart/src/classes/bbox.dart';
 export 'package:mgrs_dart/src/classes/lonlat.dart';

--- a/lib/src/classes/bbox.dart
+++ b/lib/src/classes/bbox.dart
@@ -1,16 +1,13 @@
 class BBox {
-  double top;
-  double bottom;
-  double right;
-  double left;
+  final double top;
+  final double bottom;
+  final double right;
+  final double left;
 
-  BBox({
-    required double top,
-    required double bottom,
-    required double right,
-    required double left,
-  })   : top = top,
-        bottom = bottom,
-        right = right,
-        left = left;
+  const BBox({
+    required this.top,
+    required this.bottom,
+    required this.right,
+    required this.left,
+  });
 }

--- a/lib/src/classes/lonlat.dart
+++ b/lib/src/classes/lonlat.dart
@@ -1,10 +1,9 @@
 class LonLat {
-  double lon;
-  double lat;
+  final double lon;
+  final double lat;
 
-  LonLat({
-    required double lon,
-    required double lat,
-  })   : lon = lon,
-        lat = lat;
+  const LonLat({
+    required this.lon,
+    required this.lat,
+  });
 }

--- a/lib/src/classes/utm.dart
+++ b/lib/src/classes/utm.dart
@@ -1,21 +1,33 @@
 class UTM {
-  double easting;
-  double northing;
-  String zoneLetter;
-  int zoneNumber;
-  int? accuracy;
+  final double easting;
+  final double northing;
+  final String zoneLetter;
+  final int zoneNumber;
+  final int? accuracy;
 
-  UTM(
-      {required double easting,
-      required double northing,
-      required String zoneLetter,
-      required int zoneNumber,
-      int? accuracy})
-      : easting = easting,
-        northing = northing,
-        zoneLetter = zoneLetter,
-        zoneNumber = zoneNumber,
-        accuracy = accuracy;
+  UTM({
+    required this.easting,
+    required this.northing,
+    required this.zoneLetter,
+    required this.zoneNumber,
+    this.accuracy,
+  });
+
+  UTM copyWith({
+    double? easting,
+    double? northing,
+    String? zoneLetter,
+    int? zoneNumber,
+    int? Function()? accuracy,
+  }) {
+    return UTM(
+      easting: easting ?? this.easting,
+      northing: northing ?? this.northing,
+      zoneLetter: zoneLetter ?? this.zoneLetter,
+      zoneNumber: zoneNumber ?? this.zoneNumber,
+      accuracy: accuracy != null ? accuracy() : this.accuracy,
+    );
+  }
 
   @override
   String toString() {

--- a/lib/src/mgrs.dart
+++ b/lib/src/mgrs.dart
@@ -1,4 +1,5 @@
 import 'dart:math' as math;
+
 import 'package:mgrs_dart/src/classes/bbox.dart';
 import 'package:mgrs_dart/src/classes/lonlat.dart';
 import 'package:mgrs_dart/src/classes/utm.dart';
@@ -11,9 +12,9 @@ class Mgrs {
   ///
   /// {int} @private
   ///
-  static final NUM_100K_SETS = 6;
+  static const NUM_100K_SETS = 6;
 
-  static final ALPHABET = [
+  static const ALPHABET = [
     'a',
     'b',
     'c',
@@ -44,18 +45,18 @@ class Mgrs {
 
   //The column letters (for easting) of the lower left value, per
   //set.
-  static final SET_ORIGIN_COLUMN_LETTERS = 'AJSAJS';
+  static const SET_ORIGIN_COLUMN_LETTERS = 'AJSAJS';
 
   // The row letters (for northing) of the lower left value, per
   // set.
   // {string} @private
-  static final SET_ORIGIN_ROW_LETTERS = 'AFAFAF';
+  static const SET_ORIGIN_ROW_LETTERS = 'AFAFAF';
 
-  static final A = 65; // A
-  static final I = 73; // I
-  static final O = 79; // O
-  static final V = 86; // V
-  static final Z = 90; // Z
+  static const A = 65; // A
+  static const I = 73; // I
+  static const O = 79; // O
+  static const V = 86; // V
+  static const Z = 90; // Z
 
   ///
   /// Convert MGRS to lat/lon bounding box.
@@ -84,8 +85,8 @@ class Mgrs {
     if (mgrs == '') {
       throw Exception('toPoint received a blank string');
     }
-    var utm = decode(mgrs.toUpperCase());
-    utm.accuracy = null;
+    var utm = decode(mgrs.toUpperCase()).copyWith(accuracy: () => null);
+
     var bbox = UTMtoLL(utm);
     if (bbox is LonLat) {
       return [bbox.lon, bbox.lat];
@@ -539,7 +540,7 @@ class Mgrs {
     //remove any spaces in MGRS String
     mgrsString = mgrsString.replaceAll(' ', '');
     var length = mgrsString.length;
-    var hunK;
+    String hunK;
     var sb = '';
     var i = 0;
     // get Zone number

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,14 +1,14 @@
 name: mgrs_dart
 description: Utility for converting between WGS84 lat/lng and MGRS coordinates (Dart version of proj4js/mgrs).
-version: 2.0.0
+version: 3.0.0
 homepage: https://github.com/fegyi001/mgrs_dart
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  unicode: ^0.3.0
+  unicode: ^1.1.8
 
 dev_dependencies:
-  pedantic: ^1.11.0
-  test: ^1.16.8
+  flutter_lints: ^5.0.0
+  test: ^1.25.15

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,5 +10,5 @@ dependencies:
   unicode: ^1.1.8
 
 dev_dependencies:
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
   test: ^1.25.15


### PR DESCRIPTION
This PR updates the minimum Dart version to 3.0.0, and updates all dependencies, too.

Since the `pedantic` package is discontinued, I switched to `flutter_lints`, but didn't apply any of the suggestions. I can do that as well, if you want to keep the linting clean.